### PR TITLE
add hashes table for android-support-v4.jar

### DIFF
--- a/HASHES.md
+++ b/HASHES.md
@@ -1,0 +1,18 @@
+MD5 and SHA1 hashes for v4 Support Library for Android in  v4/android-support-v4.jar
+This can help to find out which revision is in use in a project. There is no other indicator within the jar file. 
+
+|Rev.| Release date  |             md5sum               |                sha1sum                   |
+|---:|--------------:|----------------------------------|------------------------------------------|
+| 1  | March 2011    | a3191813b70f6fffb3efdd17712ee1c4 | fcbf4461f540d9e6f19cb94b3b3e8207e42f9a71 | 
+| 2  | May 2011      | 3fb707eb649b105a2175451ec208db9e | 61060ddf38258d987d6a2916dd5ac9d5a15bba10 |
+| 3  | July 2011     | 51da04a1fc400de95561214528c268e5 | fc834ac8147bc4ed0b555f90f500a57d4232c448 |
+| 4  | October 2011  | 86dfb3c6ac2db479ff396906fe4ee1be | c3029e4469274fa93dc9306a626275314e50a8e4 | 
+| 5  | December 2011 | 6ed7cfa457967cb8d5924c93b96847e7 | fb5b44c5924b42371105145c92a5825c1e7ac95d |
+| 6  | December 2011 | bcf017dfe2243c8d72b4b2aa40101040 | 7329492e76650ee661f6af7704b0c79151d8e1ef |
+| 7  | March 2012    | c6c2148762c614d3bad120ca01491e34 | 53307dc2bd2b69fd5533458ee11885f55807de4b |
+| 8  | April 2012    | 776555f10c632cd4f2790b6bbd2465bf | 8790fea7a0bc1d42c69c648571e2c7a02c92cf4c |
+| 9  | Juni 2012     | d0107ad5a43839ecdc08fbcf783bdb4f | 27c24d26e4c5d57976e6926367985548678e913c |
+| 10 | August 2012   | 7c357558b1ef5cd16f1d312fe87c38a0 | 612846c9857077a039b533718f72db3bc041d389 |
+| 11 | November 2012 | 7b5efe58fd28cbc7fa8f9e88ab9c7d65 | 48c94ae70fa65718b382098237806a5909bb096e |
+| 12 | February 2013 | 9974894df6e8ba95bb27f5e85e2cdfb5 | 307c1cc532eabbf1d135b43e5c983c9da700449d |
+| 13 | May 2013      | 5dce8843261486180715e459d953885d | bd6479f5dd592790607e0504e66e0f31c2b4d308 |


### PR DESCRIPTION
These are the hashes by md5sum and sha1sum over the android-support-v4.jar file. I have collected them to check in my projects which revision is in use. With the android-support-library-archive repository I could fill in the missing parts. Maybe someone else find them beneficial.  
